### PR TITLE
Update Travis test matricies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,10 @@ jobs:
       rvm: 2.5.7
       stage: spec
     -
+      env: PUPPET_GEM_VERSION="~> 7.0" CHECK=parallel_spec
+      rvm: 2.7.2
+      stage: spec
+    -
       env: DEPLOY_TO_FORGE=yes
       stage: deploy
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,11 +32,11 @@ jobs:
       stage: static
     -
       env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.5
+      rvm: 2.4.10
       stage: spec
     -
       env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
-      rvm: 2.5.7
+      rvm: 2.5.8
       stage: spec
     -
       env: PUPPET_GEM_VERSION="~> 7.0" CHECK=parallel_spec


### PR DESCRIPTION
This changeset adds test coverage for Puppet 7 and updates the Puppet 5 and Puppet 6 tests to use the latest Ruby versions.