### PR TITLE
Update README to use Bolt Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ There are also two complementary tasks to check the expiration date of the CA ce
 
 This module requires [Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.21.0 on either on the Master or an agent.
 
-The recommended procedure for installation this module is to use a [Bolt Puppetfile](https://puppet.com/docs/bolt/latest/installing_tasks_from_the_forge.html#task-8928).
-From within a [Boltdir](https://puppet.com/docs/bolt/latest/bolt_project_directories.html#embedded-project-directory), specify this module and `puppetlabs-stdlib` as dependencies and run `bolt puppetfile install`.
+The recommended procedure for installing this module is to use a Bolt Project.  When creating a [Bolt project](https://puppet.com/docs/bolt/latest/bolt_project_directories.html#embedded-project-directory), specify this module and `puppetlabs-stdlib` as dependencies and initialize the project.
 
 For example, to install Bolt and the required modules on a Master running EL 7:
 
@@ -68,17 +67,37 @@ sudo rpm -Uvh https://yum.puppet.com/puppet-tools-release-el-7.noarch.rpm
 sudo yum install puppet-bolt
 ```
 
+If your primary Puppet server or workstation has internet access, the project can be initialized with the needed dependencies with the following:
 ```bash
-mkdir -p ~/Boltdir
+mkdir ca_extend
 cd !$
 
-cat >>Puppetfile <<EOF
-mod 'puppetlabs-stdlib'
+bolt project init expiry --modules puppetlabs-stdlib,puppetlabs-ca_extend
+```
 
-mod 'puppetlabs-ca_extend'
-EOF
+Otherwise, if your primary Puppet server or workstation operates behind a proxy, initialize the project without the `--modules` option
+```bash
+mkdir ca_extend
+cd !$
 
-bolt puppetfile install
+bolt project init expiry
+```
+
+Then edit your `bolt-project.yaml` to use the proxy according to the [documentation](https://puppet.com/docs/bolt/latest/bolt_installing_modules.html#install-modules-using-a-proxy).  Next, add the module dependencies to `bolt-project.yaml`:
+
+```
+---
+name: expiry
+modules:
+  - name: puppetlabs-stdlib
+  - name: puppetlabs-ca_extend
+
+```
+
+Finally, install the modules.
+
+```bash
+bolt module install
 ```
 
 See the "Usage" section for how to run the tasks and plans remotely or locally on the master.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There are also two complementary tasks to check the expiration date of the CA ce
 
 ## Setup
 
-This module requires [Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.21.0 on either on the Master or an agent.
+This module requires [Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 3.0.0 on either on the Master or an agent.
 
 The recommended procedure for installing this module is to use a Bolt Project.  When creating a [Bolt project](https://puppet.com/docs/bolt/latest/bolt_project_directories.html#embedded-project-directory), specify this module and `puppetlabs-stdlib` as dependencies and initialize the project.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ca_extend",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "author": "Adrian Parreiras Horta",
   "summary": "A set of Bolt Plans and Tasks to extend the CA cert in Puppet Enterprise",
   "license": "GPL-2.0-only",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ca_extend",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "author": "Adrian Parreiras Horta",
   "summary": "A set of Bolt Plans and Tasks to extend the CA cert in Puppet Enterprise",
   "license": "GPL-2.0-only",


### PR DESCRIPTION
Prior to this commit, the instructions used a deprecated method of
installing modules using a `Boltdir`.  This commit updates the
documentation to use a Project and provides instructions for installing
behind a proxy.