### PR TITLE
Add option to regenerate the primary agent cert.

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,19 +164,11 @@ First, check the expiration of the Puppet agent certificate by running the follo
 /opt/puppetlabs/puppet/bin/openssl x509 -in "$(/opt/puppetlabs/bin/puppet config print hostcert)" -enddate -noout
 ```
 
-If, and only if, the `notAfter` date printed has already passed, then the primary Puppet server certificate has expired and must be cleaned up before the CA can be regenerated:
+If, and only if, the `notAfter` date printed has already passed, then the primary Puppet server certificate has expired and must be cleaned up before the CA can be regenerated.  This can be accomplished by passing `regen_primary_cert=true` to the `ca_extend::extend_ca_cert` plan.
+
 
 ```bash
-mkdir -p -m 0700 /var/puppetlabs/backups
-(umask 0077 && tar czf "/var/puppetlabs/backups/ssl-$(date +'%Y%m%d%H%M%S')".tar.gz "$(puppet config print ssldir)")
-
-find "$(puppet config print ssldir)" -name "$(puppet config print certname).pem" -delete
-```
-
-Once the expiration has been checked, the CA can be regenerated.
-
-```bash
-bolt plan run ca_extend::extend_ca_cert --targets <master_fqdn> compile_masters=<comma_separated_compile_master_fqdns> --run-as root
+bolt plan run ca_extend::extend_ca_cert regen_primary_cert=true --targets <master_fqdn> compile_masters=<comma_separated_compile_master_fqdns> --run-as root
 ```
 
 Note that if you are running `extend_ca_cert` locally on the primary Puppet server, you can avoid potential Bolt transport issues by specifying `--targets local://$(hostname -f)`, e.g.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -132,6 +132,7 @@ Ran on 1 node in 0.70 seconds
 
 * master - Fully-qualified domain name of the Master acting as the Certificate Authority
 * compile_masters - Optional comma-separated list of fully-qualified domain names of Compilers
+* regen_primary_cert - Boolean for whether to also regenrate the primary server certificate.  Defaults to `false`
 
 #### Steps
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "puppetlabs-ca_extend",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Adrian Parreiras Horta",
   "summary": "A set of Bolt Plans and Tasks to extend the CA cert in Puppet Enterprise",
   "license": "GPL-2.0-only",

--- a/plans/extend_ca_cert.pp
+++ b/plans/extend_ca_cert.pp
@@ -24,7 +24,7 @@ plan ca_extend::extend_ca_cert(
     unless $out.ok {
       fail_plan($out.value['message'])
     }
-    if $out.value['status'] == "warn" {
+    if $out.value['status'] == 'warn' {
       warning($out.value['message'])
     }
   }

--- a/plans/extend_ca_cert.pp
+++ b/plans/extend_ca_cert.pp
@@ -2,6 +2,7 @@ plan ca_extend::extend_ca_cert(
   TargetSpec $targets,
   Optional[TargetSpec] $compile_masters = undef,
   $ssldir                               = '/etc/puppetlabs/puppet/ssl',
+  $regen_primary_cert                   = false,
 ) {
   $targets.apply_prep
   $master_facts = run_task('facts', $targets, '_catch_errors' => true).first
@@ -18,6 +19,10 @@ plan ca_extend::extend_ca_cert(
     fail_plan("Puppet not detected on ${targets}")
   }
 
+  if $is_pe and ! $regen_primary_cert{
+    run_task('ca_extend::check_primary_cert', $targets)
+  }
+
   out::message("INFO: Stopping Puppet services on ${targets}")
   $services.each |$service| {
     run_task('service::linux', $targets, 'action' => 'stop', 'name' => $service)
@@ -30,7 +35,9 @@ plan ca_extend::extend_ca_cert(
 
   out::message("INFO: Configuring ${targets} to use the extended CA certificate")
   if $is_pe {
-    run_task('ca_extend::configure_master', $targets, 'new_cert' => $new_cert['new_cert'])
+    run_task('ca_extend::configure_master', $targets,
+      'new_cert' => $new_cert['new_cert'], 'regen_primary_cert' => $regen_primary_cert
+    )
   }
   else {
     run_command("/bin/cp ${new_cert['new_cert']} ${ssldir}/certs/ca.pem", $targets)

--- a/plans/extend_ca_cert.pp
+++ b/plans/extend_ca_cert.pp
@@ -20,7 +20,13 @@ plan ca_extend::extend_ca_cert(
   }
 
   if $is_pe and ! $regen_primary_cert{
-    run_task('ca_extend::check_primary_cert', $targets)
+    $out = run_task('ca_extend::check_primary_cert', $targets, '_catch_errors' => true).first
+    unless $out.ok {
+      fail_plan($out.value['message'])
+    }
+    if $out.value['status'] == "warn" {
+      warning($out.value['message'])
+    }
   }
 
   out::message("INFO: Stopping Puppet services on ${targets}")

--- a/tasks/check_agent_expiry.sh
+++ b/tasks/check_agent_expiry.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 declare PT__installdir
+# shellcheck disable=SC1090
 source "$PT__installdir/ca_extend/files/common.sh"
 PUPPET_BIN='/opt/puppetlabs/puppet/bin'
 
@@ -10,15 +11,17 @@ expired=()
 to_date="${date:-+3 months}"
 to_date="$(date --date="$to_date" +"%s")" || fail "Error calculating date"
 
+# It's possible that we are not on a Puppet AIO system. If we cannot find a
+# openssl binary in the AIO directory, we accept one in $PATH
+if [ "$(command -v "${PUPPET_BIN}/openssl")" ]; then
+  openssl="${PUPPET_BIN}/openssl"
+else
+  openssl="$(command -v openssl)"
+fi
+
 shopt -s nullglob
-for f in /etc/puppetlabs/puppet/ssl/ca/signed/*; do
-  # It's possible that we are not on a Puppet AIO system. If we cannot find a
-  # openssl binary in the AIO directory, we accept one in $PATH
-  if [ "$(command -v "${PUPPET_BIN}/openssl")" ]; then
-    openssl="${PUPPET_BIN}/openssl"
-  else
-    openssl="$(command -v openssl)"
-  fi
+
+for f in "$($PUPPET_BIN/puppet config print signeddir)"/*; do
   # The -checkend command in openssl takes a number of seconds as an argument
   # However, on older versions we may overflow a 32 bit integer if we use that
   # So, we'll use bash arithmetic and `date` to do the comparison
@@ -26,7 +29,7 @@ for f in /etc/puppetlabs/puppet/ssl/ca/signed/*; do
   expiry_date="${expiry_date#*=}"
   expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from enddate"
 
-  if (( $to_date >= $expiry_seconds )); then
+  if (( to_date >= expiry_seconds )); then
     expired+=("\"$f\"")
   else
     valid+=("\"$f\"")

--- a/tasks/check_ca_expiry.sh
+++ b/tasks/check_ca_expiry.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 declare PT__installdir
+# shellcheck disable=SC1090
 source "$PT__installdir/ca_extend/files/common.sh"
 PUPPET_BIN='/opt/puppetlabs/puppet/bin'
 
@@ -20,7 +21,7 @@ expiry_date="$("${PUPPET_BIN}/openssl" x509 -enddate -noout -in /etc/puppetlabs/
 expiry_date="${expiry_date#*=}"
 expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from enddate"
 
-if (( $to_date >= $expiry_seconds )); then
+if (( to_date >= expiry_seconds )); then
   success "{ \"status\": \"will expire\", \"expiry date\": \"$expiry_date\" }"
 else
   success "{ \"status\": \"valid\", \"expiry date\": \"$expiry_date\" }"

--- a/tasks/check_primary_cert.json
+++ b/tasks/check_primary_cert.json
@@ -1,0 +1,8 @@
+{
+  "description": "Check the expiration date of the primary server cert",
+  "parameters": {},
+
+  "implementations": [
+    {"name": "check_primary_cert.sh", "requirements": ["shell"], "files": ["ca_extend/files/common.sh"], "input_method": "environment"}
+  ]
+}

--- a/tasks/check_primary_cert.sh
+++ b/tasks/check_primary_cert.sh
@@ -5,14 +5,17 @@ declare PT__installdir
 source "$PT__installdir/ca_extend/files/common.sh"
 PUPPET_BIN='/opt/puppetlabs/puppet/bin'
 
-expiry_date="$($PUPPET_BIN/openssl x509 -enddate -noout -in "$($PUPPET_BIN/puppet config print hostcert)")" || {
-  fail "Error finding primary server certificate."
-}
+hostcert="$($PUPPET_BIN/puppet config print hostcert)"
+[[ -e $hostcert ]] || fail "ERROR: primary server cert not found.  pass regen_primary_cert=true to the plan to regenerate it if needed."
+
+expiry_date="$($PUPPET_BIN/openssl x509 -enddate -noout -in "$hostcert")"
 expiry_date="${expiry_date#*=}"
 expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from enddate"
 
 if (( $(date +"%s") >= expiry_seconds )); then
-  fail "Error: the primary server certificate has expired.  Please pass regen_primary_cert=true to the plan to regenerate it."
+  fail "ERROR: the primary server certificate has expired.  Please pass regen_primary_cert=true to the plan to regenerate it."
+elif (( $(date --date="+3 months" +"%s") >= expiry_seconds )); then
+  success '{ "status": "warn", "message": "WARN: Primary cert expiring within 3 months. Either regenerate manually or pass regen_primary_cert=true to the plan to regenerate it." }'
+else
+  success '{ "status": "success", "message": "Primary cert ok" }'
 fi
-
-success '{ "status": "success", "message": "Primary cert ok" }'

--- a/tasks/check_primary_cert.sh
+++ b/tasks/check_primary_cert.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+declare PT__installdir
+# shellcheck disable=SC1090
+source "$PT__installdir/ca_extend/files/common.sh"
+PUPPET_BIN='/opt/puppetlabs/puppet/bin'
+
+expiry_date="$($PUPPET_BIN/openssl x509 -enddate -noout -in "$($PUPPET_BIN/puppet config print hostcert)")" || {
+  fail "Error finding primary server certificate."
+}
+expiry_date="${expiry_date#*=}"
+expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from enddate"
+
+if (( $(date +"%s") >= expiry_seconds )); then
+  fail "Error: the primary server certificate has expired.  Please pass regen_primary_cert=true to the plan to regenerate it."
+fi
+
+success '{ "status": "success", "message": "Primary cert ok" }'

--- a/tasks/configure_master.json
+++ b/tasks/configure_master.json
@@ -4,6 +4,10 @@
     "new_cert": {
       "description": "Location of the newly generated CA certificate",
       "type": "String"
+    },
+    "regen_primary_cert": {
+      "description": "Flag to regerate the primary server's certificate.  Set to true to perform the regeneration",
+      "type": "Boolean"
     }
   },
 

--- a/tasks/configure_master.sh
+++ b/tasks/configure_master.sh
@@ -6,7 +6,7 @@ source "$PT__installdir/ca_extend/files/common.sh"
 PUPPET_BIN='/opt/puppetlabs/puppet/bin'
 
 mkdir -p /var/puppetlabs/backups/
-cp -R /etc/puppetlabs/puppet/ssl /var/puppetlabs/backups || fail "Error backing up '/etc/puppetlabs/puppet/ssl'"
+cp -aR /etc/puppetlabs/puppet/ssl /var/puppetlabs/backups || fail "Error backing up '/etc/puppetlabs/puppet/ssl'"
 
 # shellcheck disable=SC2154
 [[ $regen_primary_cert == "true" ]] && {

--- a/tasks/configure_master.sh
+++ b/tasks/configure_master.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
 declare PT__installdir
+# shellcheck disable=SC1090
 source "$PT__installdir/ca_extend/files/common.sh"
+PUPPET_BIN='/opt/puppetlabs/puppet/bin'
 
-\cp -R /etc/puppetlabs/puppet/ssl /var/puppetlabs/backups || fail "Error backing up '/etc/puppetlabs/puppet/ssl'"
+mkdir -p /var/puppetlabs/backups/
+cp -R /etc/puppetlabs/puppet/ssl /var/puppetlabs/backups || fail "Error backing up '/etc/puppetlabs/puppet/ssl'"
 
-\cp "$new_cert" /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem || fail "Error copying 'ca_crt.pem'"
-\cp "$new_cert" /etc/puppetlabs/puppet/ssl/certs/ca.pem || fail "Error copying 'ca.pem"
+# shellcheck disable=SC2154
+[[ $regen_primary_cert == "true" ]] && {
+  find "$($PUPPET_BIN/puppet config print ssldir)" -name "$($PUPPET_BIN/puppet config print certname).pem" -delete
+}
+
+# shellcheck disable=SC2154
+cp "$new_cert" /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem || fail "Error copying 'ca_crt.pem'"
+cp "$new_cert" /etc/puppetlabs/puppet/ssl/certs/ca.pem || fail "Error copying 'ca.pem"
 
 PATH="${PATH}:/opt/puppetlabs/bin" puppet infrastructure configure --no-recover || fail "Error running 'puppet infrastructure configure'"
 

--- a/tasks/extend_ca_cert.sh
+++ b/tasks/extend_ca_cert.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 declare PT__installdir
+# shellcheck disable=SC1090
 source "$PT__installdir/ca_extend/files/common.sh"
 
 echo "test" | base64 -w 0 - &>/dev/null || fail "This script requires a version of base64 with the -w flag"


### PR DESCRIPTION
Prior to this commit, the configure_master step would fail if the
primary agent cert had also expired.  This commit adds a check for this
cert's expiration and an option to regenerate it.  This is done by
deleting the pem encoded cert and keys.