### PR TITLE
Check for cadir during primary cert regen

### DIFF
--- a/tasks/check_ca_expiry.sh
+++ b/tasks/check_ca_expiry.sh
@@ -17,7 +17,7 @@ to_date="$(date --date="$to_date" +"%s")" || fail "Error calculating date"
 # The -checkend command in openssl takes a number of seconds as an argument
 # However, on older versions we may overflow a 32 bit integer if we use that
 # So, we'll use bash arithmetic and `date` to do the comparison
-expiry_date="$("${PUPPET_BIN}/openssl" x509 -enddate -noout -in /etc/puppetlabs/puppet/ssl/certs/ca.pem)"
+expiry_date="$("${PUPPET_BIN}/openssl" x509 -enddate -noout -in "$cert")"
 expiry_date="${expiry_date#*=}"
 expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from enddate"
 

--- a/tasks/configure_master.sh
+++ b/tasks/configure_master.sh
@@ -3,21 +3,24 @@
 declare PT__installdir
 # shellcheck disable=SC1090
 source "$PT__installdir/ca_extend/files/common.sh"
+
 PUPPET_BIN='/opt/puppetlabs/puppet/bin'
 ssldir="$($PUPPET_BIN/puppet config print ssldir)"
 cadir="$($PUPPET_BIN/puppet config print cadir)"
+ca_dirs=("$ssldir" "$cadir")
 
 mkdir -p /var/puppetlabs/backups/
 cp -aR "$ssldir" /var/puppetlabs/backups || fail "Error backing up '/etc/puppetlabs/puppet/ssl'"
 
 # shellcheck disable=SC2154
 [[ $regen_primary_cert == "true" ]] && {
-  find "$ssldir" -name "$($PUPPET_BIN/puppet config print certname).pem" -delete
+  # add the command substitutions to get ssldir and cadir to an array
+  find "${ca_dirs[@]}" -name "$($PUPPET_BIN/puppet config print certname).pem" -delete
 }
 
 # shellcheck disable=SC2154
 cp "$new_cert" "${cadir}/ca_crt.pem" || fail "Error copying 'ca_crt.pem'"
-cp "$new_cert" "${ssldir}/ca.pem" || fail "Error copying 'ca.pem'"
+cp "$new_cert" "${ssldir}/certs/ca.pem" || fail "Error copying 'ca.pem'"
 
 PATH="${PATH}:/opt/puppetlabs/bin" puppet infrastructure configure --no-recover || fail "Error running 'puppet infrastructure configure'"
 

--- a/tasks/configure_master.sh
+++ b/tasks/configure_master.sh
@@ -4,18 +4,20 @@ declare PT__installdir
 # shellcheck disable=SC1090
 source "$PT__installdir/ca_extend/files/common.sh"
 PUPPET_BIN='/opt/puppetlabs/puppet/bin'
+ssldir="$($PUPPET_BIN/puppet config print ssldir)"
+cadir="$($PUPPET_BIN/puppet config print cadir)"
 
 mkdir -p /var/puppetlabs/backups/
-cp -aR /etc/puppetlabs/puppet/ssl /var/puppetlabs/backups || fail "Error backing up '/etc/puppetlabs/puppet/ssl'"
+cp -aR "$ssldir" /var/puppetlabs/backups || fail "Error backing up '/etc/puppetlabs/puppet/ssl'"
 
 # shellcheck disable=SC2154
 [[ $regen_primary_cert == "true" ]] && {
-  find "$($PUPPET_BIN/puppet config print ssldir)" -name "$($PUPPET_BIN/puppet config print certname).pem" -delete
+  find "$ssldir" -name "$($PUPPET_BIN/puppet config print certname).pem" -delete
 }
 
 # shellcheck disable=SC2154
-cp "$new_cert" /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem || fail "Error copying 'ca_crt.pem'"
-cp "$new_cert" /etc/puppetlabs/puppet/ssl/certs/ca.pem || fail "Error copying 'ca.pem"
+cp "$new_cert" "${cadir}/ca_crt.pem" || fail "Error copying 'ca_crt.pem'"
+cp "$new_cert" "${ssldir}/ca.pem" || fail "Error copying 'ca.pem'"
 
 PATH="${PATH}:/opt/puppetlabs/bin" puppet infrastructure configure --no-recover || fail "Error running 'puppet infrastructure configure'"
 


### PR DESCRIPTION
Prior to this commit, regenerating the primary cert would fail on 2021
because it did not delete the signed cert from the new cadir.  This
commit fixes this by adding the ssldir and cadir to an array and passing
that to find.