### PR TITLE
(SUP-2655) Update Minimum Supported Bolt Version to 1.38.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ There are also two complementary tasks to check the expiration date of the CA ce
 
 ## Setup
 
-This module requires [Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.2.0 on either on the primary Puppet server or a workstation with connectivity to the primary.
+This module requires [Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.38.0 on either on the primary Puppet server or a workstation with connectivity to the primary.
 
 The installation procedure will differ depending on the version of Bolt.  If possible, using Bolt >= 3.0.0 is recommended.  For example, this will install the latest Bolt version on EL 7.
 
@@ -67,7 +67,7 @@ sudo yum install puppet-bolt
 
 The following two sections show how to install the module dependencies depending on the installed version of Bolt.
 
-### Bolt >= 1.2.0 < 3.0.0
+### Bolt >= 1.38.0 < 3.0.0
 
 The recommended procedure for these versions is to use a [Bolt Puppetfile](https://puppet.com/docs/bolt/latest/installing_tasks_from_the_forge.html#task-8928).
 From within a [Boltdir](https://puppet.com/docs/bolt/latest/bolt_project_directories.html#embedded-project-directory), specify this module and `puppetlabs-stdlib` as dependencies and run `bolt puppetfile install`.  For example:
@@ -131,7 +131,7 @@ See the "Usage" section for how to run the tasks and plans remotely or locally o
 
 ### Dependencies
 
-*  A [Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.21.0
+*  A [Puppet Bolt](https://puppet.com/docs/bolt/latest/bolt_installing.html) >= 1.38.0
 *  [puppetlabs-stdlib](https://puppet.com/docs/bolt/latest/bolt_installing.html)
 *  A `base64` binary on the primary Puppet server which supports the `-w` flag
 *  `bash` >= 4.0 on the primary Puppet server


### PR DESCRIPTION
Tested it is working since Bolt 1.38.0:

```
[root@pe-201819-master Boltdir]# bolt plan run ca_extend::extend_ca_cert --targets local://$(hostname -f) --run-as root
--
Starting: plan ca_extend::extend_ca_cert
Finished: plan ca_extend::extend_ca_cert in 0.0 sec
{
"kind": "bolt/pal-error",
"msg": "ca_extend::extend_ca_cert:\n  has no parameter named 'nodes'\n  expects a value for parameter 'targets'",
"details": {
}
}
[root@pe-201819-master Boltdir]# bolt --version
1.37.0
```
In 1.38.0:

```
[root@pe-201819-master Boltdir]# bolt --version
--
1.38.0
[root@pe-201819-master Boltdir]# bolt plan run ca_extend::extend_ca_cert --targets local://$(hostname -f) --run-as root
Starting: plan ca_extend::extend_ca_cert
Starting: install puppet and gather facts on pe-201819-master.puppetdebug.vlan
Finished: install puppet and gather facts with 0 failures in 3.5 sec
Starting: task facts on pe-201819-master.puppetdebug.vlan
Finished: task facts with 0 failures in 1.59 sec
Starting: task ca_extend::check_primary_cert on pe-201819-master.puppetdebug.vlan
Finished: task ca_extend::check_primary_cert with 0 failures in 0.91 sec
INFO: Stopping Puppet services on local://pe-201819-master.puppetdebug.vlan
```