### PR TITLE
(maint) Bump stdlib version

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.10.0 < 7.0.0"
+      "version_requirement": ">= 4.10.0 < 9.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Prior to this commit, the module had a depency of stdlib less than
7.0.0. This commit updates the stdlib dependency to allow 7.x and
8.x versions.