### PR TITLE
(SUP-3016) Add printing dates to agent expiry task

### DIFF
--- a/tasks/check_agent_expiry.sh
+++ b/tasks/check_agent_expiry.sh
@@ -28,7 +28,8 @@ for f in "$($PUPPET_BIN/puppet config print signeddir)"/*; do
   expiry_date="$(${openssl} x509 -enddate -noout -in "${f}")"
   expiry_date="${expiry_date#*=}"
   expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from enddate"
-
+  f="$f: $expiry_date"
+  
   if (( to_date >= expiry_seconds )); then
     expired+=("\"$f\"")
   else


### PR DESCRIPTION
example output before the change:
```
{
    "valid": [
      "/etc/puppetlabs/puppet/ssl/ca/signed/console-cert.pem",
      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-compiler-886b03-0.us-west1-a.c.customer-support-scratchpad.internal.pem",
      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-server-886b03-0.us-west1-a.c.customer-support-scratchpad.internal.pem",
      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-server-886b03-1.us-west1-b.c.customer-support-scratchpad.internal.pem",
      "/etc/puppetlabs/puppet/ssl/ca/signed/testnode-c80ae4-0.us-west1-c.c.customer-support-scratchpad.internal.pem"
    ],
    "expiring": [

    ]
  }
```

And After:
```  {"valid": ["/etc/puppetlabs/puppet/ssl/ca/signed/console-cert.pem": Aug  4 10:29:13 2024 GMT,"/etc/puppetlabs/puppet/ssl/ca/signed/pe-compiler-886b03-0.us-west1-a.c.customer-support-scratchpad.internal.pem": May  2 10:33:06 2027 GMT,"/etc/puppetlabs/puppet/ssl/ca/signed/pe-server-886b03-0.us-west1-a.c.customer-support-scratchpad.internal.pem": Apr 29 10:27:05 2037 GMT,"/etc/puppetlabs/puppet/ssl/ca/signed/pe-server-886b03-1.us-west1-b.c.customer-support-scratchpad.internal.pem": May  2 10:33:20 2027 GMT,"/etc/puppetlabs/puppet/ssl/ca/signed/testnode-c80ae4-0.us-west1-c.c.customer-support-scratchpad.internal.pem": May  2 10:58:47 2027 GMT], "expiring": []}```