### PR TITLE
(SUP-3016) Ensure valid json formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,15 +237,21 @@ Started on local://pe-server-7a5b76-0.us-west1-c.internal...
 Finished on local://pe-server-7a5b76-0.us-west1-c.internal:
   {
     "valid": [
-      "/etc/puppetlabs/puppet/ssl/ca/signed/console-cert.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-node-7a5b76-0.us-west1-c.internal.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/pe-server-7a5b76-0.us-west1-c.internal.pem",
-      "/etc/puppetlabs/puppet/ssl/ca/signed/win19-06d5fc-0.us-west1-c.internal.pem"
+      {
+        "console-cert.pem": "Jan 14 19:55:34 2024 GMT"
+      },
+      {
+        "critical-boom.delivery.puppetlabs.net.pem": "Apr 21 17:57:20 2027 GMT"
+      },
+      {
+        "irate-maple.delivery.puppetlabs.net.pem": "Apr 21 19:25:35 2027 GMT"
+      }
     ],
-    "expiring": [
+    "expired": [
 
     ]
   }
+
 Successful on 1 target: local://pe-server-7a5b76-0.us-west1-c.internal
 Ran on 1 target in 1.32 sec
 ```

--- a/tasks/check_agent_expiry.sh
+++ b/tasks/check_agent_expiry.sh
@@ -21,22 +21,37 @@ fi
 
 shopt -s nullglob
 
-for f in "$($PUPPET_BIN/puppet config print signeddir)"/*; do
+for cert in "$($PUPPET_BIN/puppet config print signeddir)"/*; do
   # The -checkend command in openssl takes a number of seconds as an argument
   # However, on older versions we may overflow a 32 bit integer if we use that
   # So, we'll use bash arithmetic and `date` to do the comparison
-  expiry_date="$(${openssl} x509 -enddate -noout -in "${f}")"
+  expiry_date="$(${openssl} x509 -enddate -noout -in "${cert}")"
   expiry_date="${expiry_date#*=}"
   expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from enddate"
-  f="$f: $expiry_date"
-  
+
+  # Only use the filename without preceding directories
+  short_cert="${cert##*/}"
+
   if (( to_date >= expiry_seconds )); then
-    expired+=("\"$f\"")
+    expired+=("\"$short_cert\"")
+    expired+=("\"$expiry_date\"")
   else
-    valid+=("\"$f\"")
+    valid+=("\"$short_cert\"")
+    valid+=("\"$expiry_date\"")
   fi
 done
 
 # This is ugly, we as of now we don't include jq binaries in Bolt
-# As long as there aren't weird characters in certnames it should be ok
-(IFS=,; printf '{"valid": [%s], "expiring": [%s]}' "${valid[*]}" "${expired[*]}")
+if (( "${#valid[@]}" > 0 )); then
+  # Construct a string of individual json objects in the form of:
+  # {"cert_1": "expiration_date"},{"cert_2": "expiration_date"},
+  # There will be a trailing comma we strip in the final echo
+  valid_output=$(printf '{%s: %s},' "${valid[@]}")
+fi
+
+if (( "${#expired[@]}" > 0 )); then
+  expired_output=$(printf '{%s: %s},' "${expired[@]}")
+fi
+
+# Create json arrays by stripping the trailing comma and adding brackets
+echo "{\"valid\": [${valid_output%,}], \"expired\": [${expired_output%,}]}"


### PR DESCRIPTION
Prior to this commit, the addition of the expiration date made the
output invalid json because it was unquoted.  This commit changes the
output format to consist of key/value pairs for each cert, e.g.

{
  "valid": [
    {
      "console-cert.pem": "Jan 14 19:55:34 2024 GMT"
    }
  ],
  "expired": [

  ]
}