### PR TITLE
(SUP-3048) Do not print cert contents

### DIFF
--- a/files/extend.sh
+++ b/files/extend.sh
@@ -72,6 +72,7 @@ EOT
 new_ca_cert="${ca_dir}/ca_crt-expires-${end_date}.pem"
 
 yes | "${PUPPET_BIN}/openssl" ca \
+  -notext \
   -in "${workdir}/ca_csr.pem" \
   -keyfile "${ca_key}" \
   -config "${workdir}/openssl.cnf" \


### PR DESCRIPTION
Prior to this commit, the openssl ca command that created the new cert
also wrote a human readable version of the cert to the file.  This
hasn't created any issues so far, since our tools only read the PEM
encoded cert inside the BEGIN/END blocks.  However, it still should not
be there.

This commit adds -notext to the command to not print the human readable
version of the cert.