### PR TITLE
(SUP-3365) Add crl_truncate 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 .envrc
 /inventory.yaml
 /spec/fixtures/litmus_inventory.yaml
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -46,13 +46,17 @@ After the CA certificate has been extended, there are three methods for distribu
 1. Manually deleting `ca.pem` on agents and letting them download that file as part of the next Puppet agent run. The agent will download that file only if it is absent, so it must be deleted to use this method.
 1. Using a Puppet file resource to manage `ca.pem`. _Note: This method is only possible if the CA certificate has not yet expired because Puppet communications depend upon a valid CA certificate._
 
-There are also two complementary tasks to check the expiration date of the CA certificate or any agent certificates.
+There are also complementary tasks to check the expiration date of the CA certificate, agent certificates, and the CA CRL.
 
 * `ca_extend::check_ca_expiry`
     * Checks if the CA certificate expires by a certain date. Defaults to three months from today.
 * `ca_extend::check_agent_expiry`
     * Checks if any agent certificate expires by a certain date. Defaults to three months from today.
-
+*  `ca_extend::check_crl_expiry`
+    * Checks if the CA crl on the primary server has expired
+*  `ca_extend::crl_truncate`
+    * Will truncate and regenerate the CA CRL, this should only be run if the CRL is expired
+  
 ** If the CA certificate is expiring or expired, you must extend it as soon as possible. **
 
 ## Setup
@@ -150,6 +154,8 @@ First, check the expiration of the Puppet agent certificate by running the follo
 ```
 
 If, and only if, the `notAfter` date printed has already passed, then the primary Puppet server certificate has expired and must be cleaned up before the CA can be regenerated.  This can be accomplished by passing `regen_primary_cert=true` to the `ca_extend::extend_ca_cert` plan.
+
+> Note: This plan will also run the `ca_extend::check_crl_cert` task and if the crl is expired, will automatically resolve the issue by running the `ca_extend::crl_truncate` task.
 
 ```bash
 bolt plan run ca_extend::extend_ca_cert regen_primary_cert=true --targets <primary_fqdn> compilers=<comma_separated_compiler_fqdns> --run-as root

--- a/plans/extend_ca_cert.pp
+++ b/plans/extend_ca_cert.pp
@@ -40,6 +40,14 @@ plan ca_extend::extend_ca_cert(
     }
   }
 
+  if $is_pe {
+    $crl_results = run_task('ca_extend::check_crl_cert', $targets)
+    if $crl_results.value['status'] == 'expired' {
+      out::message('INFO: CRL expired, truncating to regenerate')
+      $truncate_results = run_task('ca_extend::crl_truncate', $targets)
+    }
+  }
+
   out::message("INFO: Stopping Puppet services on ${targets}")
   $services.each |$service| {
     run_task('service::linux', $targets, 'action' => 'stop', 'name' => $service)

--- a/tasks/check_crl_cert.json
+++ b/tasks/check_crl_cert.json
@@ -1,0 +1,16 @@
+{
+    "description": "Check the expiration date of the primary server crl",
+    "parameters": {},
+    "implementations": [
+        {
+            "name": "check_crl_cert.sh",
+            "requirements": [
+                "shell"
+            ],
+            "files": [
+                "ca_extend/files/common.sh"
+            ],
+            "input_method": "environment"
+        }
+    ]
+}

--- a/tasks/check_crl_cert.sh
+++ b/tasks/check_crl_cert.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+declare PT__installdir
+# shellcheck disable=SC1090
+source "$PT__installdir/ca_extend/files/common.sh"
+PUPPET_BIN='/opt/puppetlabs/puppet/bin'
+
+hostcert="$($PUPPET_BIN/puppet config print cacrl)"
+[[ -e $hostcert ]] || fail "ERROR: primary server CA cert is not found."
+
+expiry_date="$($PUPPET_BIN/openssl crl -nextupdate -noout -in "$hostcert")"
+expiry_date="${expiry_date#*=}"
+expiry_seconds="$(date --date="$expiry_date" +"%s")" || fail "Error calculating expiry date from nextupdate"
+
+if (( $(date +"%s") >= expiry_seconds )); then
+  success '{ "status": "expired", "message": "Ca crl cert is expired, run the crl_truncate task to generate a new crl" }'
+else
+  success '{ "status": "success", "message": "Ca crl cert is ok" }'
+fi

--- a/tasks/crl_truncate.json
+++ b/tasks/crl_truncate.json
@@ -1,0 +1,28 @@
+{
+  "description": "Truncate the CRL issued by the Puppet CA",
+  "parameters": {
+    "ssldir": {
+      "description": "The location of the Puppet ssl dir",
+      "type": "Optional[String[1]]"
+    },
+    "crl_expiration_days": {
+      "description": "The number of days until the new CRL expires.  Defaults to 15 years (5475 days)",
+      "type": "Integer[1]",
+      "default": 5475
+    },
+    "run_puppet_agent": {
+      "description": "Whether to run the Puppet agent after creating the CRL.  Defaults to true",
+      "type": "Boolean",
+      "default": false
+    }
+  },
+  "implementations": [
+    {
+      "name": "crl_truncate.sh",
+      "requirements": [
+        "shell"
+      ],
+      "input_method": "environment"
+    }
+  ]
+}

--- a/tasks/crl_truncate.sh
+++ b/tasks/crl_truncate.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+# For compatibility wither older versions of tasks, we just shove everything in this file
+# PT_ variables can be referenced but not assigned 
+# shellcheck disable=SC2154
+# Exit with an error message and error code, defaulting to 1
+fail() {
+  # Print a stderr: entry if there were anything printed to stderr
+  if [[ -s $_tmp ]]; then
+    # Hack to try and output valid json by replacing newlines with spaces.
+    echo "{ \"status\": \"error\", \"message\": \"$1\", \"stderr\": \"$(tr '\n' ' ' <"$_tmp")\" }"
+  else
+    echo "{ \"status\": \"error\", \"message\": \"$1\" }"
+  fi
+
+  exit "${2:-1}"
+}
+
+success() {
+  echo "$1"
+  exit 0
+}
+
+_tmp="$(mktemp)"
+exec 2>>"$_tmp"
+
+# Use indirection to munge PT_ environment variables
+# e.g. "$PT_version" becomes "$version"
+for v in ${!PT_*}; do
+  declare "${v#*PT_}"="${!v}"
+done
+
+trap fail ERR
+
+(( EUID == 0 )) || fail 'This script must be run as root'
+
+cat >/tmp/openssl.cnf <<EOF
+####################################################################
+[ ca ]
+default_ca      = CA_default            # The default ca section
+
+####################################################################
+[ CA_default ]
+
+dir             = /tmp          # Where everything is kept
+certs           = \$dir/certs            # Where the issued certs are kept
+crl_dir         = \$dir          # Where the issued crl are kept
+database        = \$dir/index.txt        # database index file.
+#unique_subject = no                    # Set to 'no' to allow creation of
+                                        # several certs with same subject.
+new_certs_dir   = \$dir/newcerts         # default place for new certs.
+
+certificate     = /etc/puppetlabs/puppet/ssl/certs/ca.pem       # The CA certificate
+serial          = /etc/puppetlabs/puppet/ssl/ca/serial          # The current serial number
+crlnumber       = \$dir/crlnumber        # the current crl number
+crl             = /etc/puppetlabs/puppet/ssl/certs/ca/ca_crl.pem                # The current CRL
+private_key     = /etc/puppetlabs/puppet/ssl/ca/ca_key.pem # The private key
+
+x509_extensions = usr_cert              # The extensions to add to the cert
+
+# Comment out the following two lines for the "traditional"
+# (and highly broken) format.
+name_opt        = ca_default            # Subject Name options
+cert_opt        = ca_default            # Certificate field options
+
+# Extension copying option: use with caution.
+# copy_extensions = copy
+
+# Extensions to add to a CRL. Note: Netscape communicator chokes on V2 CRLs
+# so this is commented out by default to leave a V1 CRL.
+# crlnumber must also be commented out to leave a V1 CRL.
+crl_extensions  = crl_ext
+
+default_days     = 365                   # how long to certify for
+default_crl_days = $crl_expiration_days  # how long before next CRL
+default_md       = default               # use public key default MD
+preserve         = no                    # keep passed DN ordering
+
+# A few difference way of specifying how similar the request should look
+# For type CA, the listed attributes must be the same, and the optional
+# and supplied fields are just that :-)
+policy          = policy_match
+
+[ crl_ext ]
+# CRL extensions.
+# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
+
+# issuerAltName=issuer:copy
+authorityKeyIdentifier=keyid:always
+EOF
+
+cert_num=0
+certs=()
+PUPPET_BIN='/opt/puppetlabs/puppet/bin'
+ssldir="${ssldir:-/etc/puppetlabs/puppet/ssl}"
+
+# Create temp files for each crl in the chain to determine the root
+while IFS= read -r line; do
+   if [[ $line =~ BEGIN\ X509\ CRL ]]; then
+     # Don't trigger the error trap when incrementing returns 1
+      (( cert_num++ )) || true
+      # This will result in an undefined element 0 in the array, but should be fine
+      certs[cert_num]="$(mktemp)"
+   fi
+
+   printf '%s\n' "$line" >>"${certs[cert_num]}"
+done <"$ssldir"/ca/ca_crl.pem
+
+for cert in "${certs[@]}"; do
+   issuer="$("$PUPPET_BIN"/openssl crl -issuer -noout -in "$cert")"
+   [[ $issuer =~ Puppet\ Root\ CA ]] && root_crl="$cert"
+done
+
+# Assume that a single length crl chain is the root.
+# This was the default prior to PE 2019
+if (( cert_num == 1 )); then
+  root_crl="${certs[cert_num]}"
+elif ! [[ $root_crl ]]; then
+  printf '%s\n' 'Puppet root CA not found' >"$_tmp"
+  fail
+fi
+
+# Create an empty index
+:>/tmp/index.txt
+
+# openssl requires that the crlnumber be hex with an even number of digits
+# %02 in the format string with pad it to two characters, otherwise we have to check for evenness and add a 0 if needed
+crl_number="$("$PUPPET_BIN"/openssl crl -crlnumber -noout -in "$ssldir"/ca/ca_crl.pem)"
+# Strip everything before the '=' character and increment by one, as the docs say this should be the next crl number
+crl_number="$(printf '%02x\n' $((0x${crl_number##*=} +1 )))"
+
+# Add a leading 0 if we have an odd number of digits
+(( ${#crl_number} % 2 == 0 )) || crl_number="0${crl_number}"
+echo "$crl_number" >/tmp/crlnumber
+
+"$PUPPET_BIN"/openssl ca -config /tmp/openssl.cnf -gencrl -out /tmp/intermediate_crl.pem
+
+# For a multi-chain crl, cat the new crl with the root.  Otherwise, use only the new crl.
+if (( cert_num > 1 )); then
+  cat /tmp/intermediate_crl.pem "$root_crl" >/tmp/new_crl.pem
+
+  cp /tmp/new_crl.pem "$ssldir"/ca/ca_crl.pem
+  cp /tmp/new_crl.pem "$ssldir"/crl.pem
+else
+  cp /tmp/intermediate_crl.pem "$ssldir"/ca/ca_crl.pem
+  cp /tmp/intermediate_crl.pem "$ssldir"/crl.pem
+fi
+
+# Send errors to our temp file
+if $run_puppet_agent; then
+  "$PUPPET_BIN"/puppet agent --onetime --no-daemonize --no-usecacheonfailure --logdest "$_tmp" --log_level err
+  success '{ "status": "success", "message": "CRL truncated and Puppet agent run completed"}'
+else
+  success '{ "status": "success", "message": "CRL truncated. Puppet agent run was skipped"}'
+fi


### PR DESCRIPTION
Added a crl check task and the crl_truncate task from the module https://github.com/m0dular/crl_truncate.
The ca_extend plan checks if the crl is valid by running the check_crl_cert task, if it is expired then it runs the crl_truncate task and then continues with the ca extend. 
Used the steps from here to test - https://github.com/puppetlabs/ca_extend/issues/15.
```[root@pe-server-47748d-0 ca_extend]# bolt plan run ca_extend::extend_ca_cert --targets local://hostname --run-as root regen_primary_cert=true
CLI arguments ["run-as"] might be overridden by Inventory: /root/ca_extend/inventory.yaml [ID: cli_overrides]
Starting: plan ca_extend::extend_ca_cert
Starting: install puppet and gather facts on local://hostname
Finished: install puppet and gather facts with 0 failures in 2.29 sec
Starting: task facts on local://hostname
Finished: task facts with 0 failures in 3.84 sec
Starting: task ca_extend::check_crl_cert on local://hostname
Finished: task ca_extend::check_crl_cert with 1 failure in 0.9 sec
INFO: CRL expired, truncating to regenerate
Starting: task ca_extend::crl_truncate on local://hostname
Finished: task ca_extend::crl_truncate with 0 failures in 0.09 sec
INFO: Stopping Puppet services on local://hostname
Starting: task service::linux on local://hostname
Finished: task service::linux with 0 failures in 0.11 sec
Starting: task service::linux on local://hostname
Finished: task service::linux with 0 failures in 1.22 sec
Starting: task service::linux on local://hostname
Finished: task service::linux with 0 failures in 1.08 sec
INFO: Extending CA certificate on local://hostname
Starting: task ca_extend::extend_ca_cert on local://hostname
Finished: task ca_extend::extend_ca_cert with 0 failures in 1.93 sec
INFO: Configuring local://hostname to use the extended CA certificate
Starting: task ca_extend::configure_primary on local://hostname
Finished: task ca_extend::configure_primary with 0 failures in 120.43 sec
Starting: task service::linux on local://hostname
Finished: task service::linux with 0 failures in 0.06 sec
Starting: command 'mktemp' on localhost
Finished: command 'mktemp' with 0 failures in 0.01 sec
INFO: Extended CA certificate decoded and stored at /tmp/tmp.Wn5a656B0X
INFO: Run the 'ca_extend::upload_ca_cert' plan to distribute the extended CA certificate to agents
Finished: plan ca_extend::extend_ca_cert in 2 min, 12 sec
Plan completed successfully with no result```