### PR TITLE
(SUP-3564) Support more types of infra nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If the CA certificate is stored in any keystores, those will also need to be upd
 The functionality of this module is composed into two Plans:
 
 *  `ca_extend::extend_ca_cert`
-    * Extend the CA certificate and configure the primary Puppet server and any Compilers to use that extended certificate.
+    * Extend the CA certificate and configure the primary Puppet server and any Replica and Compilers to use that extended certificate.
 *  `ca_extend::upload_ca_cert`
     * Distribute the CA certificate to agents using transport supported by Puppet Bolt, such as `ssh` and `winrm`.
 
@@ -158,7 +158,7 @@ If, and only if, the `notAfter` date printed has already passed, then the primar
 > Note: This plan will also run the `ca_extend::check_crl_cert` task and if the crl is expired, will automatically resolve the issue by running the `ca_extend::crl_truncate` task.
 
 ```bash
-bolt plan run ca_extend::extend_ca_cert regen_primary_cert=true --targets <primary_fqdn> compilers=<comma_separated_compiler_fqdns> --run-as root
+bolt plan run ca_extend::extend_ca_cert regen_primary_cert=true --targets <primary_fqdn> replica=<replica_fqdn> compilers=<comma_separated_compiler_fqdns> --run-as root
 ```
 
 Note that if you are running `extend_ca_cert` locally on the primary Puppet server, you can avoid potential Bolt transport issues by specifying `--targets local://hostname`, e.g.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If the CA certificate is stored in any keystores, those will also need to be upd
 The functionality of this module is composed into two Plans:
 
 *  `ca_extend::extend_ca_cert`
-    * Extend the CA certificate and configure the primary Puppet server and any Replica and Compilers to use that extended certificate.
+    * Extend the CA certificate and configure the primary Puppet server, Replica, Compilers, and Postgres nodes to use that extended certificate.
 *  `ca_extend::upload_ca_cert`
     * Distribute the CA certificate to agents using transport supported by Puppet Bolt, such as `ssh` and `winrm`.
 

--- a/plans/extend_ca_cert.pp
+++ b/plans/extend_ca_cert.pp
@@ -3,7 +3,8 @@
 #   and Compilers to use the extended certificate.
 # @param targets The target node on which to run the plan.  Should be the primary Puppet server
 # @param compilers Optional comma separated list of compilers to configure to use the extended CA
-# @param replica Optional replica to configure to use the extended CA 
+# @param replica Optional replica to configure to use the extended CA
+# @param psql_nodes Optional comma separated list of psql nodes to configure to use the extended CA
 # @param ssldir Location of the ssldir on disk
 # @param regen_primary_cert Whether to also regenerate the agent certificate of the primary Puppet server
 # @example Extend the CA cert and regenerate the primary agent cert locally on the primary Puppet server
@@ -14,6 +15,7 @@ plan ca_extend::extend_ca_cert(
   TargetSpec $targets,
   Optional[TargetSpec] $compilers = undef,
   Optional[TargetSpec] $replica = undef,
+  Optional[TargetSpec] $psql_nodes = undef,
   $ssldir                               = '/etc/puppetlabs/puppet/ssl',
   $regen_primary_cert                   = false,
 ) {
@@ -22,11 +24,22 @@ plan ca_extend::extend_ca_cert(
 
   if $primary_facts['pe_build'] {
     $is_pe = true
-    $services = ['puppet', 'pe-puppetserver', 'pe-postgresql']
+
+    $primary_services = [
+      'puppet',
+      'pe-puppetserver',
+      'pe-postgresql',
+      'pe-puppetdb',
+      'pe-ace-server',
+      'pe-bolt-server',
+      'pe-console-services',
+      'pe-orchestration-services',
+    ]
+    $replica_services = ['pe-puppetserver', 'pe-postgresql', 'pe-puppetdb', 'pe-console-services']
   }
   elsif $primary_facts['puppetversion'] {
     $is_pe = false
-    $services = ['puppet', 'puppetserver']
+    $primary_services = ['puppet', 'puppetserver']
   }
   else {
     fail_plan("Puppet not detected on ${targets}")
@@ -51,7 +64,7 @@ plan ca_extend::extend_ca_cert(
   }
 
   out::message("INFO: Stopping Puppet services on ${targets}")
-  $services.each |$service| {
+  $primary_services.each |$service| {
     run_task('service::linux', $targets, 'action' => 'stop', 'name' => $service)
   }
 
@@ -81,13 +94,22 @@ plan ca_extend::extend_ca_cert(
 
   if $is_pe and $replica {
     out::message("INFO: Stopping Puppet services on ${replica}")
-    $services.each |$service| {
+    # Stop and start the puppet service manually on replicas
+    run_task('service::linux', $replica, 'action' => 'stop', 'name' => 'puppet')
+
+    $replica_services.each |$service| {
       run_task('service::linux', $replica, 'action' => 'stop', 'name' => $service)
     }
+
     out::message("INFO: Configuring the replica (${replica}) to use the extended CA certificate")
     upload_file($tmp_file, '/etc/puppetlabs/puppet/ssl/certs/ca.pem', $replica)
+
+    # Run the agent to restart the appropriate services
+    out::message("INFO: running Puppet agent on ${replica}")
     run_command('/opt/puppetlabs/bin/puppet agent --no-daemonize --no-noop --onetime', $replica)
-    run_task('service::linux', $replica, 'action' => 'start', 'name' => 'puppet')
+
+    # Re-enable the Puppet service
+    run_task('service::linux', $compilers, 'action' => 'start', 'name' => 'puppet')
   }
 
   if $compilers {
@@ -97,9 +119,54 @@ plan ca_extend::extend_ca_cert(
     out::message("INFO: Configuring compilers (${compilers}) to use the extended CA certificate")
     upload_file($tmp_file, '/etc/puppetlabs/puppet/ssl/certs/ca.pem', $compilers)
 
-    # Just running Puppet with the new CA certificate in place should be enough.
+    if $is_pe {
+      # Use the service::linux task to check if PDB is running on compilers and restart it if so
+      $pdb_compilers = run_task('service::linux', $compilers, 'action' => 'status', 'name' => 'pe-puppetdb').filter_set |$compiler| {
+      $compiler['enabled'] !~ /^Failed to get unit file state/ }.map |$result| {
+        $result.target
+      }
+      $legacy_compilers = get_targets($compilers) - $pdb_compilers
+
+      unless $pdb_compilers.empty {
+        out::message('INFO: stopping services on PDB compilers')
+        ['pe-puppetserver', 'pe-puppetdb'].each |$service| {
+          run_task('service::linux', $pdb_compilers, 'action' => 'stop', 'name' => $service)
+        }
+      }
+
+      unless $legacy_compilers.empty {
+        out::message('INFO: stopping services on legacy compilers')
+        run_task('service::linux', $legacy_compilers, 'action' => 'stop', 'name' => 'pe-puppetserver')
+      }
+    }
+    else {
+      out::message('INFO: stopping services on compilers')
+      run_task('service::linux', $compilers, 'action' => 'stop', 'name' => 'pe-puppetserver')
+    }
+
+    # Run the agent to restart the appropriate services
+    out::message("INFO: running Puppet agent on ${compilers}")
     run_command('/opt/puppetlabs/bin/puppet agent --no-daemonize --no-noop --onetime', $compilers)
+
+    # Re-enable the Puppet service
     run_task('service::linux', $compilers, 'action' => 'start', 'name' => 'puppet')
+  }
+
+  if $psql_nodes {
+    out::message("INFO: Stopping Puppet services on psql nodes (${psql_nodes})")
+    ['puppet', 'pe-postgresql'].each |$service| {
+      run_task('service::linux', $psql_nodes, 'action' => 'stop', 'name' => $service)
+    }
+
+    out::message("INFO: Configuring psql nodes (${psql_nodes}) to use the extended CA certificate")
+    upload_file($tmp_file, '/etc/puppetlabs/puppet/ssl/certs/ca.pem', $psql_nodes)
+
+    # Run the agent to restart the appropriate services
+    out::message("INFO: running Puppet agent on ${psql_nodes}")
+    run_command('/opt/puppetlabs/bin/puppet agent --no-daemonize --no-noop --onetime', $psql_nodes)
+
+    # Re-enable the Puppet service
+    run_task('service::linux', $psql_nodes, 'action' => 'start', 'name' => 'puppet')
   }
 
   out::message("INFO: Extended CA certificate decoded and stored at ${tmp_file}")

--- a/plans/upload_ca_cert.pp
+++ b/plans/upload_ca_cert.pp
@@ -2,7 +2,8 @@
 #   A plan to upload a given CA certificate to a number of Puppet agent nodes
 # @param nodes The targets to upload the certificate to
 # @param cert The location of the CA certificate on disk of the local machine
-# @return JSON object with two keys: success and failure. Each key contains any number of objects consisting of the agent certname and the output of the upload_file command
+# @return JSON object with two keys: success and failure.
+#   Each key contains any number of objects consisting of the agent certname and the output of the upload_file command
 plan ca_extend::upload_ca_cert(
   TargetSpec $nodes,
   String     $cert


### PR DESCRIPTION
This patch resolves SUP-3564 and SUP-4394 and adds support for more types of Puppet infra nodes:

* Replicas
* PDB Compilers
* Postgres nodes